### PR TITLE
Fix optionality of nullable parent and `required|nullable` keys

### DIFF
--- a/src/Validation/RuleTreeNode.php
+++ b/src/Validation/RuleTreeNode.php
@@ -97,7 +97,11 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
                 Rule::RULE_EXCLUDE_WITHOUT,
                 Rule::RULE_SOMETIMES => $this->sometimes = true,
 
-                Rule::RULE_NULLABLE => $this->nullable = $this->optional = true,
+                // `nullable` makes the value accept null. It only relaxes presence (sets
+                // optional=true) if `required` hasn't already been posted on this node —
+                // `['required', 'nullable']` means "key must be present, value may be null",
+                // not "key may be absent".
+                Rule::RULE_NULLABLE => $this->applyNullable(),
 
                 Rule::RULE_ARRAY => $this->isArray = true,
 
@@ -108,6 +112,17 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
             $this->rules[] = $rule;
         }
         return $this;
+    }
+
+    private function applyNullable(): void
+    {
+        $this->nullable = true;
+        foreach ($this->rules as $rule) {
+            if ($rule->getRuleName() === Rule::RULE_REQUIRED) {
+                return;
+            }
+        }
+        $this->optional = true;
     }
 
     /**
@@ -155,9 +170,13 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
 
         $isRequired = false;
         foreach ($this->children as $child) {
-            $isRequired = $isRequired || !$child->resolveOptional();
+            $childOptional = $child->resolveOptional();
+            $isRequired = $isRequired || !$childOptional;
         }
-        $this->hasRequiredChild = $isRequired;
+        // A nullable parent can be absent regardless of whether its children are required:
+        // child `required` rules are conditional on the parent being present and non-null,
+        // so they must not bubble up and force the parent to be required.
+        $this->hasRequiredChild = $isRequired && !$this->nullable;
         return $this->isOptional();
     }
 

--- a/tests/StructureInferenceTest.php
+++ b/tests/StructureInferenceTest.php
@@ -33,6 +33,7 @@ class StructureInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/factory.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/function.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/map.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/structure/nullable-parent.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/readme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/request.php');
     }

--- a/tests/rules/nullable.php
+++ b/tests/rules/nullable.php
@@ -12,6 +12,6 @@ $validator = \Illuminate\Support\Facades\Validator::make([], [
 assertType('Illuminate\\Validation\\Validator', $validator);
 
 $validated = $validator->validated();
-assertType('array{required_value?: string|null, optional_value?: string|null}', $validated);
+assertType('array{required_value: string|null, optional_value?: string|null}', $validated);
 assertType('string|null', $validated['required_value']);
 assertType('string|null', $validated['optional_value']);

--- a/tests/structure/nullable-parent.php
+++ b/tests/structure/nullable-parent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+// A `nullable` parent with a `required` child must remain optional:
+// the child's `required` rule is conditional on the parent being present and non-null,
+// so it must not force the parent to be required.
+
+$validator = \Illuminate\Support\Facades\Validator::make([], [
+    'parent' => 'array|nullable',
+    'parent.thing' => 'required|string',
+]);
+assertType('Illuminate\\Validation\\Validator', $validator);
+
+$validated = $validator->validated();
+assertType('array{parent?: array{thing: string}|null}', $validated);
+
+// Same pattern with a wildcard child:
+$validator2 = \Illuminate\Support\Facades\Validator::make([], [
+    'something' => 'array|nullable',
+    'something.*' => 'required|string',
+]);
+
+$validated2 = $validator2->validated();
+assertType('array{something?: array<int|string, string>|null}', $validated2);
+
+// Two siblings sharing the same shape must both be optional:
+$validator3 = \Illuminate\Support\Facades\Validator::make([], [
+    'something' => 'array|nullable',
+    'something.*' => 'required|string',
+    'else' => 'array|nullable',
+    'else.*' => 'required|string',
+]);
+
+$validated3 = $validator3->validated();
+assertType('array{something?: array<int|string, string>|null, else?: array<int|string, string>|null}', $validated3);
+
+// `required` + `nullable` on the same node: key must be present, value may be null.
+$validator4 = \Illuminate\Support\Facades\Validator::make([], [
+    'parent' => 'required|array|nullable',
+    'parent.thing' => 'required|string',
+]);
+
+$validated4 = $validator4->validated();
+assertType('array{parent: array{thing: string}|null}', $validated4);


### PR DESCRIPTION
## Summary

Two related bugs in `RuleTreeNode` optionality resolution that surface in nested validation rules:

### 1. `['required', 'nullable']` was inferred as optional

```php
'foo' => 'required|string|nullable'
```

was inferred as `array{foo?: string|null}` instead of `array{foo: string|null}`.

`Rule::RULE_NULLABLE` unconditionally executed `$this->optional = true`, overwriting `optional = false` set by `Required`. Fixed by introducing `applyNullable()` which sets `nullable = true` and only sets `optional = true` if no `Required` rule has already been posted on the same node.

### 2. `nullable` parent + `required` child forced parent to be required

```php
'parent' => 'array|nullable',
'parent.thing' => 'required|string',
```

was inferred as `array{parent: array{thing: string}|null}` (parent required) instead of `array{parent?: array{thing: string}|null}`. Same issue with wildcard children (`parent.*`).

`resolveOptional()` propagates `hasRequiredChild` from any non-optional child up to the parent. But child `required` rules are conditional on the parent being present and non-null — Laravel only validates them once the parent exists. They must not bubble up and force the parent itself to be required. Fixed by skipping the propagation when the parent is itself nullable.

## Tests

- New fixture `tests/structure/nullable-parent.php` covers both fixes with 4 patterns (nullable parent + required child, nullable parent with wildcard required, two siblings sharing the shape, and the `required|nullable` interaction).
- Existing `tests/rules/nullable.php` encoded bug #1 in its expected type and is updated to the now-correct expectation.

## Test results

- All 1750 tests run, 251 assertions pass (vs 246 before — +5 from the new fixture).
- The 1506 pre-existing errors are unchanged: they are PHP 8.5 warnings (`Undefined variable $ruleName` in `TypeResolver::evaluateLeaf()`) that `failOnWarning="true"` upgrades to errors. Same count on `master` without my changes — unrelated to this PR.