### PR TITLE
Fix evaluateLeaf $ruleName, sometimes-parent propagation, Bool/Int aliases

### DIFF
--- a/src/Validation/RuleParser.php
+++ b/src/Validation/RuleParser.php
@@ -123,8 +123,15 @@ final class RuleParser
 
     public static function normalizeName(string $str): string
     {
-        return implode(array_map(function (string $word) {
+        $name = implode(array_map(function (string $word) {
             return ucfirst($word);
         }, explode(' ', str_replace(['-', '_'], ' ', $str))));
+
+        // Mirror \Illuminate\Validation\ValidationRuleParser::normalizeRule().
+        return match ($name) {
+            'Int' => 'Integer',
+            'Bool' => 'Boolean',
+            default => $name,
+        };
     }
 }

--- a/src/Validation/RuleTreeNode.php
+++ b/src/Validation/RuleTreeNode.php
@@ -173,10 +173,11 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
             $childOptional = $child->resolveOptional();
             $isRequired = $isRequired || !$childOptional;
         }
-        // A nullable parent can be absent regardless of whether its children are required:
-        // child `required` rules are conditional on the parent being present and non-null,
-        // so they must not bubble up and force the parent to be required.
-        $this->hasRequiredChild = $isRequired && !$this->nullable;
+        // A parent that can legitimately be absent — because it is `nullable`, has
+        // `sometimes`, or has a conditional `exclude_*`/`accepted_if`/`declined_if`
+        // (all of which set `$sometimes`) — must not be forced back to required by
+        // its children: child `required` rules only apply once the parent is present.
+        $this->hasRequiredChild = $isRequired && !$this->nullable && !$this->sometimes;
         return $this->isOptional();
     }
 

--- a/src/Validation/TypeResolver.php
+++ b/src/Validation/TypeResolver.php
@@ -97,7 +97,7 @@ final class TypeResolver
     public function evaluateLeaf(RuleTreeNode $node): Type\Type
     {
         $isNullable = !empty(array_filter(array_map(function ($rule) {
-            return $ruleName === 'Nullable';
+            return $rule->getRuleName() === 'Nullable';
         }, $node->getRules())));
 
         $acceptNull = !empty(array_filter(array_map(function ($rule) {

--- a/tests/StructureInferenceTest.php
+++ b/tests/StructureInferenceTest.php
@@ -34,6 +34,7 @@ class StructureInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/function.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/map.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/nullable-parent.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/structure/sometimes-parent.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/readme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/request.php');
     }

--- a/tests/structure/sometimes-parent.php
+++ b/tests/structure/sometimes-parent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+// A parent with `exclude_if` is conditionally absent. Its `required` children
+// must not force the parent itself to be required — Laravel only validates
+// child rules once the parent is present.
+//
+// Reference: Laravel's testExcludeIf "nested-03" case in
+// tests/Validation/ValidationValidatorTest.php (`appointments` excluded when
+// `has_appointments` is false, even though its rules include `required`).
+
+$validator = \Illuminate\Support\Facades\Validator::make([], [
+    'has_appointments' => 'required|bool',
+    'appointments' => 'exclude_if:has_appointments,false|required|array',
+    'appointments.*.date' => 'required|date',
+    'appointments.*.name' => 'required|string',
+]);
+assertType('Illuminate\\Validation\\Validator', $validator);
+
+$validated = $validator->validated();
+assertType(
+    "array{has_appointments: 0|1|'0'|'1'|bool, appointments?: array<int|string, array{date: DateTimeInterface|non-empty-string, name: string}>}",
+    $validated,
+);
+
+// `exclude_unless` has the same effect as `exclude_if` here.
+$validator2 = \Illuminate\Support\Facades\Validator::make([], [
+    'flag' => 'required|bool',
+    'payload' => 'exclude_unless:flag,true|required|array',
+    'payload.*' => 'required|string',
+]);
+
+$validated2 = $validator2->validated();
+assertType(
+    "array{flag: 0|1|'0'|'1'|bool, payload?: array<int|string, string>}",
+    $validated2,
+);
+
+// Bare `sometimes` on the parent has the same semantics: child `required`
+// rules don't force the parent to exist.
+$validator3 = \Illuminate\Support\Facades\Validator::make([], [
+    'config' => 'sometimes|array',
+    'config.timeout' => 'required|integer',
+]);
+
+$validated3 = $validator3->validated();
+assertType('array{config?: array{timeout: int|numeric-string}}', $validated3);


### PR DESCRIPTION
## Summary

Three related bugs surfaced by running the test suite on PHP 8.5 and cross-checking against Laravel's own validation tests.

### 1. `evaluateLeaf` referenced an undefined `$ruleName`

`TypeResolver::evaluateLeaf()` had a closure that read `$ruleName` without ever defining it (the variable was only defined in the *next* closure):

```php
$isNullable = !empty(array_filter(array_map(function ($rule) {
    return $ruleName === 'Nullable';   // <- undefined
}, $node->getRules())));
```

Result: `$isNullable` was always `false`. On PHP 8.5 this surfaces as `Undefined variable $ruleName` warnings; combined with `failOnWarning="true"` in `phpunit.xml.dist`, that turned 1500+ passing tests into errors.

### 2. `hasRequiredChild` over-propagated through `sometimes` parents

After fix #1 enabled the full test suite to actually run, six `exclude_if` / `exclude_unless` cases failed because parents with `sometimes`-class rules were marked as required when they had `required` descendants.

The same logic that already exempts `nullable` parents (PR #4) needs to apply to `sometimes`. `Sometimes`, `ExcludeIf`, `ExcludeUnless`, `ExcludeWith`, `ExcludeWithout`, `AcceptedIf`, `DeclinedIf` all set `\$sometimes = true` and all mean "the parent might be absent". Their child `required` rules must not bubble up — Laravel only validates child rules once the parent is present (verified against Laravel's `testValidateImplicitEachWithAsterisksForRequiredNonExistingKey`: `['data' => [], 'rules' => ['names.*.first' => 'required']]` passes).

### 3. `Bool` / `Int` rule aliases produced `mixed`

Laravel's `ValidationRuleParser::normalizeRule()` maps `Bool → Boolean` and `Int → Integer`. The extension's `RuleParser::normalizeName()` did not, so `bool`/`int` rules fell through `TypeResolver::resolveType()`'s match and resolved to `MixedType`. Mirrored Laravel's mapping.

## Tests

- Full test suite: 1506 errors / 1 failure → 0 errors / 0 failures (1754 tests, 3267 assertions).
- New fixture `tests/structure/sometimes-parent.php` covers the `exclude_if`/`exclude_unless`/`sometimes` parent semantics — verified against Laravel's own `testExcludeIf` "nested-03" case where `appointments` is excluded when `has_appointments=false` despite having `required` in its rules.

## Follow-ups (not in this PR)

- Fixtures `tests/fixtures/laravel-export-v9.php` and `laravel-export-v10.php` are auto-generated from Laravel 9/10 via `scripts/valid-test-extractor.bash` (which needs `uopz`). Regenerating them against Laravel 13 deserves its own PR once a uopz environment is available.