### PR TITLE
Add tests for class-based validation rules with @phpstan-assert

### DIFF
--- a/tests/Fixtures/Rules/NullableArrayValue.php
+++ b/tests/Fixtures/Rules/NullableArrayValue.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+final class NullableArrayValue implements ValidationRule
+{
+    public bool $implicit = true;
+
+    /**
+     * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @phpstan-assert null|array<mixed> $value
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/NullableUint.php
+++ b/tests/Fixtures/Rules/NullableUint.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+final class NullableUint implements ValidationRule
+{
+    public bool $implicit = true;
+
+    /**
+     * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @phpstan-assert null|int<0, 4294967295> $value
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}

--- a/tests/Fixtures/Rules/RequiredString.php
+++ b/tests/Fixtures/Rules/RequiredString.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+final class RequiredString implements ValidationRule
+{
+    public bool $implicit = true;
+
+    /**
+     * @param Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     * @phpstan-assert string $value
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+    }
+}

--- a/tests/StructureInferenceTest.php
+++ b/tests/StructureInferenceTest.php
@@ -37,6 +37,7 @@ class StructureInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/function.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/map.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/nullable-parent.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/structure/rule-class.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/sometimes-parent.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/readme.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/request.php');

--- a/tests/structure/rule-class.php
+++ b/tests/structure/rule-class.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules\NullableArrayValue;
+use jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules\NullableUint;
+use jbboehr\PhpstanLaravelValidation\Test\Fixtures\Rules\RequiredString;
+
+use function PHPStan\Testing\assertType;
+
+// Custom validation rule classes that expose their refined value type via
+// `@phpstan-assert` on `validate()`. The extension picks the assert up via
+// `Evaluator/UnsafeConstExprEvaluator::getValueFromType()` and turns it into
+// a `PHPStanType` rule.
+
+// 1. Required class rule: key must be present, value is the asserted type.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'name' => [new RequiredString()],
+])->validated();
+assertType('array{name: string}', $validated);
+
+// 2. Nullable class rule: key is optional, value is null or the asserted type.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'count' => [new NullableUint()],
+])->validated();
+assertType('array{count?: int<0, 4294967295>|null}', $validated);
+
+// 3. Nullable array parent + uint wildcard child: parent optional, items keep
+//    their refined type. (Exercises the implicit-parent + nullable-parent
+//    fixes alongside the class-rule resolution.)
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'ids'   => [new NullableArrayValue()],
+    'ids.*' => [new NullableUint()],
+])->validated();
+assertType('array{ids?: array<int|string, int<0, 4294967295>|null>|null}', $validated);
+
+// 4. Nested optional parent with class rules on dotted children — Laravel
+//    only validates the children when the parent is present, so the parent
+//    must stay optional even though every child is required.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'range'            => [new NullableArrayValue()],
+    'range.start_date' => [new RequiredString(), 'date'],
+    'range.end_date'   => [new RequiredString(), 'date'],
+])->validated();
+assertType(
+    'array{range?: array{start_date: non-empty-string, end_date: non-empty-string}|null}',
+    $validated,
+);


### PR DESCRIPTION
## Summary

The extension already supports custom validation rule classes that declare their refined value type via `@phpstan-assert` on `validate()` (resolved by `Evaluator/UnsafeConstExprEvaluator::getValueFromType()` and emitted as a `PHPStanType` rule), but until now no fixture exercised that path. This means regressions on the class-rule code path could land silently.

## What's added

Three minimal `ValidationRule` fixtures under `tests/Fixtures/Rules/`:

- `RequiredString` — `@phpstan-assert string \$value`, `\$implicit = true`
- `NullableUint` — `@phpstan-assert null|int<0, 4294967295> \$value`
- `NullableArrayValue` — `@phpstan-assert null|array<mixed> \$value`

A structure fixture (`tests/structure/rule-class.php`) asserts the inferred `validated()` shape for four representative patterns:

1. Required class rule:
   ```
   array{name: string}
   ```
2. Nullable class rule:
   ```
   array{count?: int<0, 4294967295>|null}
   ```
3. Nullable array parent + nullable-uint wildcard child — exercises both the implicit-parent and nullable-parent fixes from PR #6 alongside the class-rule resolution:
   ```
   array{ids?: array<int|string, int<0, 4294967295>|null>|null}
   ```
4. Nullable parent + dotted children class rules — Laravel only validates the children when the parent is present, so the parent stays optional even though every child is required:
   ```
   array{range?: array{start_date: non-empty-string, end_date: non-empty-string}|null}
   ```

## Test results

`OK (2742 tests, 5236 assertions)` — 4 new assertions, no other change.