### PR TITLE
Fix conditional `required_*` rules + don't pollute custom-typed unions with empty string

### DIFF
--- a/src/Validation/Rule.php
+++ b/src/Validation/Rule.php
@@ -25,6 +25,12 @@ final class Rule
     public const RULE_ACCEPTED_IF = "AcceptedIf";
     public const RULE_DECLINED_IF = "DeclinedIf";
     public const RULE_REQUIRED = "Required";
+    public const RULE_REQUIRED_IF = "RequiredIf";
+    public const RULE_REQUIRED_UNLESS = "RequiredUnless";
+    public const RULE_REQUIRED_WITH = "RequiredWith";
+    public const RULE_REQUIRED_WITH_ALL = "RequiredWithAll";
+    public const RULE_REQUIRED_WITHOUT = "RequiredWithout";
+    public const RULE_REQUIRED_WITHOUT_ALL = "RequiredWithoutAll";
     public const RULE_EXCLUDE = "Exclude";
     public const RULE_EXCLUDE_IF = "ExcludeIf";
     public const RULE_EXCLUDE_UNLESS = "ExcludeUnless";
@@ -40,6 +46,12 @@ final class Rule
         self::RULE_ACCEPTED_IF => self::RULE_ACCEPTED_IF,
         self::RULE_DECLINED_IF => self::RULE_DECLINED_IF,
         self::RULE_REQUIRED => self::RULE_REQUIRED,
+        self::RULE_REQUIRED_IF => self::RULE_REQUIRED_IF,
+        self::RULE_REQUIRED_UNLESS => self::RULE_REQUIRED_UNLESS,
+        self::RULE_REQUIRED_WITH => self::RULE_REQUIRED_WITH,
+        self::RULE_REQUIRED_WITH_ALL => self::RULE_REQUIRED_WITH_ALL,
+        self::RULE_REQUIRED_WITHOUT => self::RULE_REQUIRED_WITHOUT,
+        self::RULE_REQUIRED_WITHOUT_ALL => self::RULE_REQUIRED_WITHOUT_ALL,
         self::RULE_EXCLUDE => self::RULE_EXCLUDE,
         self::RULE_EXCLUDE_IF => self::RULE_EXCLUDE_IF,
         self::RULE_EXCLUDE_UNLESS => self::RULE_EXCLUDE_UNLESS,

--- a/src/Validation/RuleTreeNode.php
+++ b/src/Validation/RuleTreeNode.php
@@ -82,8 +82,22 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
     {
         foreach ($rules as $rule) {
             match ($rule->getRuleName()) {
-                // These imply the node is not optional
+                // Plain `required` is unconditional.
                 Rule::RULE_REQUIRED => $this->optional = false,
+
+                // Conditional `required_*` rules: only treat the node as
+                // required when the predicate field is the node's *direct
+                // parent*. That's the pattern where the conditional reduces
+                // to "if parent is present, child must be present" (the
+                // shape `{parent?: {child: ...}}`). When the predicate field
+                // sits elsewhere in the tree we can't make a sound type-level
+                // claim, so we leave the node optional.
+                Rule::RULE_REQUIRED_IF,
+                Rule::RULE_REQUIRED_UNLESS,
+                Rule::RULE_REQUIRED_WITH,
+                Rule::RULE_REQUIRED_WITH_ALL,
+                Rule::RULE_REQUIRED_WITHOUT,
+                Rule::RULE_REQUIRED_WITHOUT_ALL => $this->maybeRequiredFromConditional($rule),
 
                 // This removes the node completely
                 Rule::RULE_EXCLUDE => $this->excluded = true,
@@ -114,13 +128,91 @@ final class RuleTreeNode implements IteratorAggregate, \Countable
         return $this;
     }
 
+    /**
+     * Decides whether a conditional `required_*` rule should mark this node
+     * as required from a type-inference perspective.
+     *
+     * The conditional variants reference another attribute by name:
+     *  - `required_with:other` / `required_with_all:other,other2`
+     *  - `required_without:other` / `required_without_all:other,other2`
+     *  - `required_if:other,value[,...]`
+     *  - `required_unless:other,value[,...]`
+     *
+     * Their semantics depend on a sibling, the parent, or any other attribute.
+     * We can only make a sound `optional = false` claim when the referenced
+     * field is the **direct parent** of this node — that pattern collapses
+     * to "if the parent exists, the child must exist", which is exactly
+     * what the inferred shape `{parent?: {child: ...}}` already encodes.
+     *
+     * For every other case (siblings, ancestors further up, unrelated
+     * paths) the rule remains a runtime-only enforcement and the type stays
+     * optional.
+     */
+    private function maybeRequiredFromConditional(Rule $rule): void
+    {
+        $parentPath = $this->parentPath();
+        if ($parentPath === null) {
+            return;
+        }
+        foreach ($this->referencedFields($rule) as $field) {
+            if ($field === $parentPath) {
+                $this->optional = false;
+                return;
+            }
+        }
+    }
+
+    private function parentPath(): ?string
+    {
+        $pos = strrpos($this->path, '.');
+        if ($pos === false) {
+            return null;
+        }
+        return substr($this->path, 0, $pos);
+    }
+
+    /**
+     * Extracts the attribute names this `required_*` rule references.
+     *
+     * `required_with` / `required_with_all` / `required_without` /
+     * `required_without_all` take a list of field names; `required_if` and
+     * `required_unless` take `field,value[,more_values...]` so only the
+     * first parameter is a field name.
+     *
+     * @return list<string>
+     */
+    private function referencedFields(Rule $rule): array
+    {
+        $params = $rule->getParameters();
+        if (count($params) === 0) {
+            return [];
+        }
+
+        $fields = match ($rule->getRuleName()) {
+            Rule::RULE_REQUIRED_IF, Rule::RULE_REQUIRED_UNLESS => [$params[0]],
+            Rule::RULE_REQUIRED_WITH,
+            Rule::RULE_REQUIRED_WITH_ALL,
+            Rule::RULE_REQUIRED_WITHOUT,
+            Rule::RULE_REQUIRED_WITHOUT_ALL => $params,
+            default => [],
+        };
+
+        return array_values(array_filter(
+            array_map(static fn($f) => is_string($f) ? $f : null, $fields),
+            static fn(?string $f): bool => $f !== null,
+        ));
+    }
+
     private function applyNullable(): void
     {
         $this->nullable = true;
-        foreach ($this->rules as $rule) {
-            if ($rule->getRuleName() === Rule::RULE_REQUIRED) {
-                return;
-            }
+        // Keep `optional=false` when a presence-implying rule has already
+        // been posted. We don't re-scan `$this->rules` here because
+        // conditional `required_*` variants only set `optional=false` when
+        // they target the direct parent — checking the flag directly is the
+        // single source of truth.
+        if ($this->optional === false) {
+            return;
         }
         $this->optional = true;
     }

--- a/src/Validation/TypeResolver.php
+++ b/src/Validation/TypeResolver.php
@@ -220,18 +220,18 @@ final class TypeResolver
             default => $this->resolveDefault($rule),
         };
 
-        if ($nullable && $rule !== null) {
-            $rule = Type\TypeCombinator::union(
-                $rule,
-                new Type\NullType(),
-                new ConstantStringType(""),
-            );
-        }
-        elseif ($acceptNull && $rule !== null) {
-            $rule = Type\TypeCombinator::union(
-                $rule,
-                new Type\NullType(),
-            );
+        if (($nullable || $acceptNull) && $rule !== null) {
+            // Always allow null when the node is nullable (either via Laravel's
+            // `nullable` rule or because a custom PHPStanType rule explicitly
+            // includes null). Also include the empty string — Laravel passes
+            // present-but-empty values through type rules. BUT: if a custom
+            // PHPStanType is present, trust its precision (e.g. an explicit
+            // `non-empty-string|null`) and do not inject `''`, otherwise the
+            // intersect with later rules collapses the refined type into a
+            // looser `string`.
+            $rule = $acceptNull
+                ? Type\TypeCombinator::union($rule, new Type\NullType())
+                : Type\TypeCombinator::union($rule, new Type\NullType(), new ConstantStringType(""));
         }
 
         return $rule;

--- a/tests/StructureInferenceTest.php
+++ b/tests/StructureInferenceTest.php
@@ -37,6 +37,7 @@ class StructureInferenceTest extends \PHPStan\Testing\TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/function.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/map.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/nullable-parent.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/structure/required-conditional.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/rule-class.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/sometimes-parent.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/structure/readme.php');

--- a/tests/structure/required-conditional.php
+++ b/tests/structure/required-conditional.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+// `required_with:parent` on a *direct child of `parent`* reduces to
+// "if parent exists, child must exist", so it's sound to mark the child
+// as required inside the parent's shape.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'parent'            => 'array|nullable',
+    'parent.start_date' => 'required_with:parent|string|date',
+    'parent.end_date'   => 'required_with:parent|string|date',
+])->validated();
+assertType(
+    'array{parent?: array{start_date: non-empty-string, end_date: non-empty-string}|null}',
+    $validated,
+);
+
+// `required_unless:parent,null` has the same effect for a direct child.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'parent'            => 'array|nullable',
+    'parent.start_date' => 'required_unless:parent,null|string|date',
+])->validated();
+assertType(
+    'array{parent?: array{start_date: non-empty-string}|null}',
+    $validated,
+);
+
+// `required_with:sibling` referencing a *sibling* (not the parent) must
+// stay optional — the type can't encode the cross-field condition soundly.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'a' => 'required_with:b|string',
+    'b' => 'string',
+])->validated();
+assertType('array{a?: string, b?: string}', $validated);
+
+// `required_if:other,value` with `other` being a sibling also stays optional.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'flag'  => 'required|string',
+    'value' => 'required_if:flag,enabled|string',
+])->validated();
+assertType('array{flag: string, value?: string}', $validated);
+
+// Plain `required` is unconditional — still marks the field as required.
+$validated = \Illuminate\Support\Facades\Validator::make([], [
+    'name' => 'required|string',
+])->validated();
+assertType('array{name: string}', $validated);


### PR DESCRIPTION
## Summary

Two related improvements.

### 1. Sound handling of conditional `required_*` rules

`required_if`, `required_unless`, `required_with`, `required_with_all`, `required_without`, `required_without_all` previously fell through `RuleTreeNode::push()`'s `default => null` branch and left the node optional. Always treating them as `Required` would be wrong — they reference another attribute and the predicate may not hold (e.g. `'a' => 'required_with:b'` with both at the root: `a` is only required if `b` is present, so `a?:` is the correct shape).

The new `maybeRequiredFromConditional()` only marks the node as `optional = false` when the referenced field is the **direct parent** of the node. That's the pattern that reduces to "if parent exists, child must exist" — exactly what `{parent?: {child: ...}}` already encodes. Every other case (sibling, ancestor further up, unrelated path) stays optional.

`required_if:other,value` / `required_unless:other,value` only take their first parameter as a field name; the rest are values, so the helper extracts the field accordingly.

### 2. Don't inject `''` when a custom `PHPStanType` is present

`TypeResolver::resolveType()` used to union every nullable node's type with `null` *and* `ConstantStringType('')` to model Laravel's "empty string passes type rules" behaviour. That collapsed a precise custom type (e.g. `non-empty-string|null` emitted by a `@phpstan-assert` on a `ValidationRule` class) into a loose `string|null` once intersected with a follow-up rule like `date_format`.

When a `PHPStanType` rule is on the node (`\$acceptNull = true`), the code now trusts its precision and only unions with `null`. Plain `nullable` without a custom type keeps the existing `null + ''` behaviour.

### 3. `applyNullable()` reuses the `optional` flag

Now that `optional = false` can be set by either `Required` or a direct-parent conditional, `applyNullable()` no longer re-scans the rule list. It just checks `\$this->optional === false` — single source of truth.

## Tests

New `tests/structure/required-conditional.php` covers:
- parent-targeted `required_with` / `required_unless` (child marked required inside parent shape),
- sibling-targeted `required_with` / `required_if` (child stays optional),
- plain `required` (still unconditional).

Full suite: **2747 tests, 5241 assertions, 0 failures**.